### PR TITLE
2 Directivas estructurales

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,9 @@
 <main>
-  <div class="content">
-    Cleaned HTML
-  </div>
+  <h1>Apex Angular BootCamp</h1>
+  <h2>Ejercicios:</h2>
+  <ol>
+    <li>
+      <app-directivas-estructurales></app-directivas-estructurales>
+    </li>
+  </ol>
 </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,12 +1,12 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-
+import { DirectivasEstructuralesComponent } from "./components/directivas-estructurales/directivas-estructurales.component";
 @Component({
-  selector: 'app-root',
-  standalone: true,
-  imports: [RouterOutlet],
-  templateUrl: './app.component.html',
-  styleUrl: './app.component.sass'
+    selector: 'app-root',
+    standalone: true,
+    templateUrl: './app.component.html',
+    styleUrl: './app.component.sass',
+    imports: [RouterOutlet, DirectivasEstructuralesComponent]
 })
 export class AppComponent {
   title = 'ApexAngularBootCamp';

--- a/src/app/components/directivas-estructurales/directivas-estructurales.component.html
+++ b/src/app/components/directivas-estructurales/directivas-estructurales.component.html
@@ -1,13 +1,13 @@
 <div>Directivas estructurales</div>
 <h2>NgFor</h2>
 <ul>
-    <li *ngFor="let letter of lettersArray; index as i;">
+    <li *ngFor="let letter of letters">
         {{letter}}
     </li>
 </ul>
 <h2>NgIf</h2>
 <ul>
-    <ng-container *ngFor="let letter of lettersArray; index as i;">
+    <ng-container *ngFor="let letter of letters">
         <li *ngIf="letter !== 'B'">
             {{letter}}
         </li>
@@ -15,7 +15,7 @@
 </ul>
 <h2>NgSwitch</h2>
 <ul>
-    <ng-container *ngFor="let letter of lettersArray; index as i;">
+    <ng-container *ngFor="let letter of letters">
         <li [ngSwitch]="letter">
             <span *ngSwitchCase="'A'">1</span>
             <span *ngSwitchCase="'B'">2</span>

--- a/src/app/components/directivas-estructurales/directivas-estructurales.component.html
+++ b/src/app/components/directivas-estructurales/directivas-estructurales.component.html
@@ -1,0 +1,25 @@
+<div>Directivas estructurales</div>
+<h2>NgFor</h2>
+<ul>
+    <li *ngFor="let letter of lettersArray; index as i;">
+        {{letter}}
+    </li>
+</ul>
+<h2>NgIf</h2>
+<ul>
+    <ng-container *ngFor="let letter of lettersArray; index as i;">
+        <li *ngIf="letter !== 'B'">
+            {{letter}}
+        </li>
+    </ng-container>
+</ul>
+<h2>NgSwitch</h2>
+<ul>
+    <ng-container *ngFor="let letter of lettersArray; index as i;">
+        <li [ngSwitch]="letter">
+            <span *ngSwitchCase="'A'">1</span>
+            <span *ngSwitchCase="'B'">2</span>
+            <span *ngSwitchCase="'C'">3</span>
+        </li>
+    </ng-container>
+</ul>

--- a/src/app/components/directivas-estructurales/directivas-estructurales.component.spec.ts
+++ b/src/app/components/directivas-estructurales/directivas-estructurales.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DirectivasEstructuralesComponent } from './directivas-estructurales.component';
+
+describe('DirectivasEstructuralesComponent', () => {
+  let component: DirectivasEstructuralesComponent;
+  let fixture: ComponentFixture<DirectivasEstructuralesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DirectivasEstructuralesComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(DirectivasEstructuralesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/directivas-estructurales/directivas-estructurales.component.ts
+++ b/src/app/components/directivas-estructurales/directivas-estructurales.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-directivas-estructurales',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './directivas-estructurales.component.html',
+  styleUrl: './directivas-estructurales.component.sass'
+})
+export class DirectivasEstructuralesComponent {
+  public lettersArray: string[] = ['A', 'B', 'C'];
+}

--- a/src/app/components/directivas-estructurales/directivas-estructurales.component.ts
+++ b/src/app/components/directivas-estructurales/directivas-estructurales.component.ts
@@ -9,5 +9,5 @@ import { CommonModule } from '@angular/common';
   styleUrl: './directivas-estructurales.component.sass'
 })
 export class DirectivasEstructuralesComponent {
-  public lettersArray: string[] = ['A', 'B', 'C'];
+  public letters: string[] = ['A', 'B', 'C'];
 }


### PR DESCRIPTION
Ø ngFor

- Renderizar un arreglo de strings [“A”, “B”, “C”] usando ngFor

Ø ngIf

- Mostrar del arreglo anterior solo los ítems que no equivalgan a “B” usando ngIf

Ø ngSwitch

- Para la misma lista anterior, en otro apartado, usar ngSwitch de tal forma que si el item es “A” mostrar el número 1, “B” el número 2 y “C” el número 3 respectivamente.

SS:
![image](https://github.com/CsrCornejo/ApexAngularBootCamp/assets/5630680/2fb99105-5d28-4289-9add-5acef1a5c4a1)
